### PR TITLE
Loosen requirement on Django version in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license="BSD",
     packages=find_packages(exclude=["test_project", ]),
     install_requires=[
-        "django<1.9",
+        "django<2.0",
     ],
     zip_safe=False,
     include_package_data=True,


### PR DESCRIPTION
Django 1.9 and 1.10 are supported. Deprecation warnings only exist for Django 2.0 when running the tests.